### PR TITLE
FIxed support MFA for 3.26.2010.0 PNP Version

### DIFF
--- a/reindex-users.ps1
+++ b/reindex-users.ps1
@@ -63,5 +63,5 @@ if ( $url.tolower() -notlike '*-admin*') {
     Write-Host "This script has to be executed against the admin site of SPO. Eg. https://tenant-admin.sharepoint.com" -ForegroundColor Yellow
     return
 }
-Connect-PnPOnline -Url $url -SPOManagementShell -SkipTenantAdminCheck
+Connect-PnPOnline -Url $url -SkipTenantAdminCheck -UseWebLogin
 Reset-UserProfiles -siteUrl $url


### PR DESCRIPTION
Hi Mikael,

When I wanted to use  SPO-Trigger-Reindex script I got an unauthorized error.
Probably the issue was recently changed support of MFA in Connect-PnPOnline.
When you remove -SPOManagementShell and add -UseWebLogin parameter it works :)